### PR TITLE
Add turret console control system

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/TurretConsoleSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/TurretConsoleSystem.cs
@@ -1,0 +1,110 @@
+using Content.Shared.Interaction.Events;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Interaction;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
+using Content.Server.DeviceLinking.Systems;
+using Content.Server.Mind;
+
+namespace Content.Server.Weapons.Ranged.Systems;
+
+/// <summary>
+/// Handles players remotely controlling turrets via consoles.
+/// </summary>
+public sealed class TurretConsoleSystem : EntitySystem
+{
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly DeviceLinkSystem _signal = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<TurretConsoleComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<TurretConsoleComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<TurretConsoleComponent, NewLinkEvent>(OnNewLink);
+        SubscribeLocalEvent<TurretConsoleComponent, PortDisconnectedEvent>(OnPortDisconnected);
+        SubscribeLocalEvent<TurretConsoleComponent, InteractHandEvent>(OnInteract);
+        SubscribeLocalEvent<TurretConsoleComponent, ComponentShutdown>(OnShutdown);
+    }
+
+    private void OnInteract(EntityUid uid, TurretConsoleComponent comp, InteractHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = true;
+
+        if (!_interaction.InRangeUnobstructed(args.User, uid))
+            return;
+
+        // If already controlling, release control.
+        if (comp.Controller == args.User)
+        {
+            if (_mind.TryGetMind(args.User, out var mindId, out var mind))
+            {
+                _mind.UnVisit(mindId, mind);
+                comp.Controller = null;
+            }
+            return;
+        }
+
+        // Already in use by another player.
+        if (comp.Controller != null)
+            return;
+
+        if (!_mind.TryGetMind(args.User, out var mindId2, out var mind2))
+            return;
+
+        if (comp.Turret == null || !EntityManager.EntityExists(comp.Turret))
+            return;
+
+        comp.Controller = args.User;
+        _mind.Visit(mindId2, comp.Turret.Value, mind2);
+    }
+
+    private void OnShutdown(EntityUid uid, TurretConsoleComponent comp, ComponentShutdown args)
+    {
+        if (comp.Controller == null)
+            return;
+
+        if (_mind.TryGetMind(comp.Controller.Value, out var mindId, out var mind) && mind.VisitingEntity == comp.Turret)
+        {
+            _mind.UnVisit(mindId, mind);
+        }
+    }
+
+    private void OnInit(EntityUid uid, TurretConsoleComponent comp, ComponentInit args)
+    {
+        _signal.EnsureSourcePorts(uid, TurretConsoleComponent.TurretPort);
+    }
+
+    private void OnMapInit(EntityUid uid, TurretConsoleComponent comp, MapInitEvent args)
+    {
+        if (!TryComp<DeviceLinkSourceComponent>(uid, out var source))
+            return;
+
+        if (source.Outputs.TryGetValue(TurretConsoleComponent.TurretPort, out var sinks))
+        {
+            foreach (var sink in sinks)
+            {
+                comp.Turret = sink;
+                break;
+            }
+        }
+    }
+
+    private void OnNewLink(EntityUid uid, TurretConsoleComponent comp, NewLinkEvent args)
+    {
+        if (args.Source != uid || args.SourcePort != TurretConsoleComponent.TurretPort)
+            return;
+
+        comp.Turret = args.Sink;
+    }
+
+    private void OnPortDisconnected(EntityUid uid, TurretConsoleComponent comp, PortDisconnectedEvent args)
+    {
+        if (args.Port == TurretConsoleComponent.TurretPort)
+            comp.Turret = null;
+    }
+}

--- a/Content.Shared/Weapons/Ranged/Components/TurretConsoleComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/TurretConsoleComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// Added to a console that allows remotely controlling a turret.
+/// </summary>
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TurretConsoleComponent : Component
+{
+    public const string TurretPort = "TurretControl";
+
+    /// <summary>
+    /// The turret entity that this console controls.
+    /// Set when linked via <see cref="TurretPort"/>.
+    /// </summary>
+    [ViewVariables]
+    public EntityUid? Turret;
+
+    /// <summary>
+    /// Current entity controlling the turret via this console.
+    /// </summary>
+    [DataField, ViewVariables]
+    public EntityUid? Controller;
+}

--- a/Resources/Locale/en-US/_strings/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/_strings/machine-linking/receiver_ports.ftl
@@ -76,6 +76,9 @@ signal-port-description-set-particle-zeta = Sets the type of particle this devic
 signal-port-name-set-particle-sigma = Set particle type: sigma
 signal-port-description-set-particle-sigma = Sets the type of particle this device emits to sigma.
 
+signal-port-name-turret-control = Turret link
+signal-port-description-turret-control = Accepts a connection from a turret console.
+
 signal-port-name-logic-input-a = Input A
 signal-port-description-logic-input-a = First input of a logic gate.
 

--- a/Resources/Locale/en-US/_strings/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/en-US/_strings/machine-linking/transmitter_ports.ftl
@@ -69,3 +69,6 @@ signal-port-description-power-charging = This port is invoked with HIGH when the
 
 signal-port-name-power-discharging = Discharging
 signal-port-description-power-discharging = This port is invoked with HIGH when the battery is losing charge and LOW when not.
+
+signal-port-name-turret-control = Turret link
+signal-port-description-turret-control = Used to link a turret console with a turret.

--- a/Resources/Locale/ru-RU/_strings/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/ru-RU/_strings/machine-linking/receiver_ports.ftl
@@ -50,6 +50,9 @@ signal-port-name-set-particle-zeta = Выбрать тип частиц: зет�
 signal-port-description-set-particle-zeta = Устанавливает тип частиц, излучаемых этим устройством, на зета.
 signal-port-name-set-particle-sigma = Выбрать тип частиц: сигма
 signal-port-description-set-particle-sigma = Устанавливает тип частиц, излучаемых этим устройством, на сигма.
+
+signal-port-name-turret-control = Связь с турелью
+signal-port-description-turret-control = Принимает соединение от консоли турели.
 signal-port-name-logic-input-a = Порт А
 signal-port-description-logic-input-a = Первый порт логического элемента.
 signal-port-name-logic-input-b = Порт В

--- a/Resources/Locale/ru-RU/_strings/machine-linking/transmitter_ports.ftl
+++ b/Resources/Locale/ru-RU/_strings/machine-linking/transmitter_ports.ftl
@@ -46,3 +46,6 @@ signal-port-name-power-charging = Зарядка
 signal-port-description-power-charging = Этот порт задействуется с высоким уровнем сигнала когда батарея заряжается, и с низким когда нет.
 signal-port-name-power-discharging = Разрядка
 signal-port-description-power-discharging = Этот порт задействуется с высоким уровнем сигнала когда батарея разряжается, и с низким когда нет.
+
+signal-port-name-turret-control = Связь с турелью
+signal-port-description-turret-control = Используется для соединения консоли турели с самой турелью.

--- a/Resources/Prototypes/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/sink_ports.yml
@@ -127,3 +127,8 @@
   id: SetParticleSigma
   name: signal-port-name-set-particle-sigma
   description: signal-port-description-set-particle-sigma
+
+- type: sinkPort
+  id: TurretControl
+  name: signal-port-name-turret-control
+  description: signal-port-description-turret-control

--- a/Resources/Prototypes/DeviceLinking/source_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/source_ports.yml
@@ -154,3 +154,8 @@
   id: PowerDischarging
   name: signal-port-name-power-discharging
   description: signal-port-description-power-discharging
+
+- type: sourcePort
+  id: TurretControl
+  name: signal-port-name-turret-control
+  description: signal-port-description-turret-control

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml
@@ -1,3 +1,4 @@
+---
 - type: entity
   parent: BaseStructure
   id: WeaponTurretSyndicateBroken
@@ -257,3 +258,21 @@
       interactFailureString: petting-failure-generic
       interactSuccessSound:
         path: /Audio/Animals/snake_hiss.ogg
+
+- type: entity
+  parent: BaseWeaponTurret
+  id: WeaponTurretConsole
+  name: console turret
+  suffix: Console
+  components:
+  - type: NpcFactionMember
+    factions:
+      - NanoTrasen
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+      - TurretControl

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/turretconsole.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/turretconsole.yml
@@ -1,0 +1,17 @@
+---
+- type: entity
+  parent: BaseComputer
+  id: ComputerTurretConsole
+  name: turret console
+  description: Used to remotely control a turret.
+  components:
+    - type: TurretConsole
+    - type: DeviceList
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+    - type: WirelessNetworkConnection
+      range: 200
+    - type: DeviceLinkSource
+      range: 5
+      ports:
+        - TurretControl


### PR DESCRIPTION
## Summary
- add `TurretConsoleComponent` linking constant and dynamic turret field
- expand `TurretConsoleSystem` to use DeviceLinking for multitool linking
- introduce `TurretControl` ports and localization
- update turret console and turret prototypes with device link components
- fix YAML indentation for turret console prototype

## Testing
- `yamllint Resources/Prototypes/Entities/Structures/Machines/Computers/turretconsole.yml`
- `yamllint Resources/Prototypes/Entities/Objects/Weapons/Guns/turrets.yml` *(fails with many warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6863e2388018833188e2f9213662f379